### PR TITLE
Resolves #160: Move the Home button to the top left of the page

### DIFF
--- a/pages/about.module.css
+++ b/pages/about.module.css
@@ -28,6 +28,7 @@
 }
 
 .buttonWrapper {
+  align-self: flex-start;
   margin-bottom: 24px;
   max-width: 240px;
   width: 100%;

--- a/pages/guidebook.module.css
+++ b/pages/guidebook.module.css
@@ -5,6 +5,7 @@
 }
 
 .buttonWrapper {
+  align-self: flex-start;
   margin-bottom: 36px;
   max-width: 240px;
   width: 100%;

--- a/pages/mixtape.module.css
+++ b/pages/mixtape.module.css
@@ -5,6 +5,7 @@
 }
 
 .buttonWrapper {
+  align-self: flex-start;
   margin-bottom: 24px;
   max-width: 240px;
   width: 100%;

--- a/pages/recommend.module.css
+++ b/pages/recommend.module.css
@@ -1,4 +1,5 @@
 .linkWrapper {
+  align-self: flex-start;
   margin-bottom: 24px;
   max-width: 240px;
   width: 100%;


### PR DESCRIPTION
Resolves #160.

Added `align-self: flex-start` to the `.buttonWrapper` / `.linkWrapper` CSS class in all non-home pages (about, mixtape, guidebook, recommend). This overrides the parent flex container's `align-items: center`, pulling the 'Go Home' button to the left edge — the standard back-button position.