### PR TITLE
Resolves #157: Fix search bar jumping

### DIFF
--- a/components/search-bar.js
+++ b/components/search-bar.js
@@ -56,11 +56,17 @@ export default function SearchBar({
         placeholder={placeholder.text.slice(0, placeholder.index)}
       />
 
-      {recommendations.length !== filteredRecommendations.length && (
-        <p className={styles.count}>{`${filteredRecommendations.length} result${
-          filteredRecommendations.length !== 1 ? "s" : ""
-        }`}</p>
-      )}
+      <p
+        className={styles.count}
+        style={{
+          visibility:
+            recommendations.length !== filteredRecommendations.length
+              ? "visible"
+              : "hidden",
+        }}
+      >{`${filteredRecommendations.length} result${
+        filteredRecommendations.length !== 1 ? "s" : ""
+      }`}</p>
     </div>
   );
 }


### PR DESCRIPTION
Resolves #157.

The result count <p> was conditionally rendered, causing the search bar to shift position when results appeared/disappeared. Changed to always render the element but toggle visibility: hidden/visible — this holds the space in the layout so the search bar stays stationary.