### PR TITLE
Resolves #158: Animate in recommendation modal

### DIFF
--- a/components/dialog.module.css
+++ b/components/dialog.module.css
@@ -1,5 +1,30 @@
+@keyframes dialogOverlayFadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes dialogPopIn {
+  0% {
+    opacity: 0;
+    transform: scale(0.8) translateY(24px);
+  }
+  60% {
+    opacity: 1;
+    transform: scale(1.03) translateY(-4px);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
 .dialogOverlay {
   background-color: var(--overlay);
+  animation: dialogOverlayFadeIn 0.2s ease-out;
 }
 .dialogOverlay.dark {
   background-color: var(--overlay-dark);
@@ -15,6 +40,14 @@
   border-radius: var(--border-radius);
   border: var(--border);
   position: relative;
+  animation: dialogPopIn 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dialogOverlay,
+  .dialog {
+    animation: none;
+  }
 }
 .dialog.dark {
   background-color: var(--dark);


### PR DESCRIPTION
Resolves #158.

Adds a bouncy pop-in CSS keyframe animation to the Dialog component (scale from 0.8 + slide up, spring overshoot, settles). Backdrop fades in over 0.2s. Uses cubic-bezier for cartoony 'boing' feel. Includes prefers-reduced-motion guard.